### PR TITLE
fix(templates): resolve GetX strict analyzer warnings and refactor auth UI to GetView

### DIFF
--- a/templates/flutter/base/lib/src/app.dart.hbs
+++ b/templates/flutter/base/lib/src/app.dart.hbs
@@ -1,4 +1,4 @@
-import 'package:{{flags.appSnake}}/src/imports/core_imports.dart';
+import 'package:{{flags.appSnake}}/src/imports/imports.dart';
 
 class App extends StatelessWidget {
   const App({super.key});

--- a/templates/flutter/base/lib/src/imports/packages_imports.dart.hbs
+++ b/templates/flutter/base/lib/src/imports/packages_imports.dart.hbs
@@ -22,14 +22,7 @@ export 'package:provider/provider.dart' hide Dispose;
 export 'package:flutter_bloc/flutter_bloc.dart';
 {{/if}}
 {{#if (or flags.isGetX (eq flags.routerPackage "getx"))}}
-// For Navigation
-export 'package:get/get_navigation/get_navigation.dart' hide GetContextExtensions;
-// For State Management (.obs, GetxController, Obx)
-{{#if flags.isGetX}}
-export 'package:get/get_state_manager/get_state_manager.dart';
-// For Dependency Management (Get.put, Get.find)
-export 'package:get/get_instance/get_instance.dart';
-{{/if}}
+export 'package:get/get.dart' hide ContextExtensionss, Trans, StringExtension;
 {{/if}}
 {{#if flags.isMobX}}
 export 'package:mobx/mobx.dart' hide version, StringExtension, Action, Listener, Listenable, Interceptor, Interceptors;

--- a/templates/flutter/base/lib/src/routing/(isGetX)@app_bindings.dart.hbs
+++ b/templates/flutter/base/lib/src/routing/(isGetX)@app_bindings.dart.hbs
@@ -8,7 +8,7 @@ import 'package:{{flags.appSnake}}/src/controllers/auth/auth_controller.dart';
 {{else if (eq architecture "mvvm")}}
 import 'package:{{flags.appSnake}}/src/ui/auth/controllers/auth_controller.dart';
 {{else}}
-import 'package:{{flags.appSnake}}/src/features/auth/presentation/controllers/auth_controller.dart';
+import 'package:{{flags.appSnake}}/src/features/auth/presentation/providers/auth_controller.dart';
 {{/if}}
 
 class AppBindings implements Bindings {

--- a/templates/flutter/base/lib/src/routing/app_router.dart.hbs
+++ b/templates/flutter/base/lib/src/routing/app_router.dart.hbs
@@ -108,63 +108,26 @@ class AppRouter extends RootStackRouter {
 }
 {{else if (eq flags.routerPackage "getx")}}
 import 'package:{{flags.appSnake}}/src/imports/imports.dart';
-import 'package:{{flags.appSnake}}/src/routing/app_routes.dart';
-
-{{#if (eq architecture "layer-first")}}
-import 'package:{{flags.appSnake}}/src/presentation/screens/auth/login_screen.dart';
-import 'package:{{flags.appSnake}}/src/presentation/screens/auth/signup_screen.dart';
-import 'package:{{flags.appSnake}}/src/presentation/screens/auth/forgot_password_screen.dart';
-{{else if (eq architecture "mvc")}}
-import 'package:{{flags.appSnake}}/src/views/auth/login_screen.dart';
-import 'package:{{flags.appSnake}}/src/views/auth/signup_screen.dart';
-import 'package:{{flags.appSnake}}/src/views/auth/forgot_password_screen.dart';
-{{else if (eq architecture "mvvm")}}
-import 'package:{{flags.appSnake}}/src/ui/auth/login_screen.dart';
-import 'package:{{flags.appSnake}}/src/ui/auth/signup_screen.dart';
-import 'package:{{flags.appSnake}}/src/ui/auth/forgot_password_screen.dart';
-{{else}}
-import 'package:{{flags.appSnake}}/src/features/auth/presentation/screens/login_screen.dart';
-import 'package:{{flags.appSnake}}/src/features/auth/presentation/screens/signup_screen.dart';
-import 'package:{{flags.appSnake}}/src/features/auth/presentation/screens/forgot_password_screen.dart';
-{{/if}}
-
-{{#if (eq architecture "layer-first")}}
-import 'package:{{flags.appSnake}}/src/presentation/screens/home/home_page.dart';
-import 'package:{{flags.appSnake}}/src/presentation/screens/onboarding/onboarding_page.dart';
-
-{{else if (eq architecture "mvc")}}
-import 'package:{{flags.appSnake}}/src/views/home/home_page.dart';
-import 'package:{{flags.appSnake}}/src/views/onboarding/onboarding_page.dart';
-
-{{else if (eq architecture "mvvm")}}
-import 'package:{{flags.appSnake}}/src/ui/home/home_page.dart';
-import 'package:{{flags.appSnake}}/src/ui/onboarding/onboarding_page.dart';
-
-{{else}}
-import 'package:{{flags.appSnake}}/src/features/home/presentation/screens/home_page.dart';
-import 'package:{{flags.appSnake}}/src/features/onboarding/presentation/screens/onboarding_page.dart';
-
-{{/if}}
 
 class AppRouter {
-  static List<GetPage> get getPages => [
-    GetPage(
+  static List<GetPage<dynamic>> get getPages => [
+    GetPage<dynamic>(
       name: AppRoutes.onboarding,
       page: () => const OnboardingPage(),
     ),
-    GetPage(
+    GetPage<dynamic>(
       name: AppRoutes.login,
       page: () => const LoginScreen(),
     ),
-    GetPage(
+    GetPage<dynamic>(
       name: AppRoutes.signup,
       page: () => const SignupScreen(),
     ),
-    GetPage(
+    GetPage<dynamic>(
       name: AppRoutes.forgotPassword,
       page: () => const ForgotPasswordScreen(),
     ),
-    GetPage(
+    GetPage<dynamic>(
       name: AppRoutes.home,
       page: () => const HomePage(),
     ),

--- a/templates/flutter/base/lib/src/shared/wrappers/session_listener_wrapper.dart.hbs
+++ b/templates/flutter/base/lib/src/shared/wrappers/session_listener_wrapper.dart.hbs
@@ -116,9 +116,9 @@ class _SessionListenerWrapperState extends State<SessionListenerWrapper> {
           FlutterNativeSplash.remove();
           {{/if}}
           if (status == SessionStatus.authenticated) {
-            Get.offAllNamed(AppRoutes.home);
+            Get.offAllNamed<dynamic>(AppRoutes.home);
           } else if (status == SessionStatus.unauthenticated) {
-            Get.offAllNamed(AppRoutes.onboarding);
+            Get.offAllNamed<dynamic>(AppRoutes.onboarding);
           }
         }
       }, condition: () => session.status.value != SessionStatus.unknown);

--- a/templates/flutter/base/pubspec.yaml.hbs
+++ b/templates/flutter/base/pubspec.yaml.hbs
@@ -45,7 +45,9 @@ dependencies:
   flutter_bloc: ^9.1.1
   {{/if}}
   {{#if flags.isGetX}}
+  {{#unless (eq flags.routerPackage "getx")}}
   get: ^4.7.3
+  {{/unless}}
   {{/if}}
   {{#if flags.isProvider}}
   provider: ^6.1.5+1

--- a/templates/flutter/partials/features/auth/auth_logic.hbs
+++ b/templates/flutter/partials/features/auth/auth_logic.hbs
@@ -451,6 +451,37 @@ class AuthController extends GetxController {
 
   final isLoading = false.obs;
 
+  // Login controllers & states
+  final loginFormKey = GlobalKey<FormState>();
+  final emailController = TextEditingController();
+  final passwordController = TextEditingController();
+  final obscurePassword = true.obs;
+
+  // SignUp controllers & states
+  final signUpFormKey = GlobalKey<FormState>();
+  final nameController = TextEditingController();
+  final signUpEmailController = TextEditingController();
+  final signUpPasswordController = TextEditingController();
+  final signUpConfirmPasswordController = TextEditingController();
+  final signUpObscurePassword = true.obs;
+  final signUpObscureConfirmPassword = true.obs;
+
+  // ForgotPassword controllers & states
+  final forgotPasswordFormKey = GlobalKey<FormState>();
+  final forgotPasswordEmailController = TextEditingController();
+
+  @override
+  void onClose() {
+    emailController.dispose();
+    passwordController.dispose();
+    nameController.dispose();
+    signUpEmailController.dispose();
+    signUpPasswordController.dispose();
+    signUpConfirmPasswordController.dispose();
+    forgotPasswordEmailController.dispose();
+    super.onClose();
+  }
+
   void login({required BuildContext context, required String email, required String password}) async {
     isLoading.value = true;
     
@@ -464,7 +495,7 @@ class AuthController extends GetxController {
         }
       },
       (user) {
-        Get.offAllNamed(AppRoutes.home);
+        Get.offAllNamed<dynamic>(AppRoutes.home);
       },
     );
   }
@@ -482,7 +513,7 @@ class AuthController extends GetxController {
         }
       },
       (user) {
-        Get.offAllNamed(AppRoutes.home);
+        Get.offAllNamed<dynamic>(AppRoutes.home);
       },
     );
   }
@@ -503,7 +534,7 @@ class AuthController extends GetxController {
         if (context.mounted) {
           showToast(context, message: 'Password reset link sent successfully', status: 'success');
         }
-        Get.offNamed(AppRoutes.login);
+        Get.offNamed<dynamic>(AppRoutes.login);
       },
     );
   }

--- a/templates/flutter/partials/features/auth/forgot_password_screen.hbs
+++ b/templates/flutter/partials/features/auth/forgot_password_screen.hbs
@@ -8,7 +8,7 @@ import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}pr
 {{else if flags.isProvider}}
 import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}presentation/providers/{{else if (eq architecture "mvc")}}controllers/auth/{{else if (eq architecture "mvvm")}}ui/auth/providers/{{else}}features/auth/presentation/providers/{{/if}}auth_provider.dart';
 {{else if flags.isGetX}}
-import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}presentation/controllers/auth/{{else if (eq architecture "mvc")}}controllers/auth/{{else if (eq architecture "mvvm")}}ui/auth/controllers/{{else}}features/auth/presentation/controllers/{{/if}}auth_controller.dart';
+import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}presentation/controllers/auth/{{else if (eq architecture "mvc")}}controllers/auth/{{else if (eq architecture "mvvm")}}ui/auth/controllers/{{else}}features/auth/presentation/providers/{{/if}}auth_controller.dart';
 {{else if flags.isMobX}}
 {{#if flags.usesFlutterHooks}}
 import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}presentation/providers/{{else if (eq architecture "mvc")}}controllers/auth/{{else if (eq architecture "mvvm")}}ui/auth/stores/{{else}}features/auth/presentation/providers/{{/if}}auth_store.dart';
@@ -22,6 +22,41 @@ import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}pr
 {{#if (eq flags.routerPackage "auto_route")}}
 @RoutePage()
 {{/if}}
+{{#if flags.isGetX}}
+{{#if (eq flags.routerPackage "auto_route")}}
+@RoutePage()
+{{/if}}
+class ForgotPasswordScreen extends GetView<AuthController> {
+  const ForgotPasswordScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = context.theme.colorScheme;
+    final tt = context.theme.textTheme;
+
+    Future<void> handleForgotPassword() async {
+      if (!(controller.forgotPasswordFormKey.currentState?.validate() ?? false)) return;
+
+      controller.forgotPassword(
+        context: context, 
+        email: controller.forgotPasswordEmailController.text,
+      );
+    }
+
+    return Obx(() {
+      final isLoading = controller.isLoading.value;
+      return _ForgotPasswordView(
+        formKey: controller.forgotPasswordFormKey,
+        emailController: controller.forgotPasswordEmailController,
+        isLoading: isLoading,
+        onForgotPassword: handleForgotPassword,
+        cs: cs,
+        tt: tt,
+      );
+    });
+  }
+}
+{{else}}
 {{#if flags.usesFlutterHooks}}
 class ForgotPasswordScreen extends {{#if flags.isRiverpod}}HookConsumerWidget{{else}}HookWidget{{/if}} {
   const ForgotPasswordScreen({super.key});
@@ -273,6 +308,7 @@ class _ForgotPasswordScreenState extends {{#if flags.isRiverpod}}ConsumerState<F
     {{/if}}
   }
 }
+{{/if}}
 {{/if}}
 
 class _ForgotPasswordView extends StatelessWidget {

--- a/templates/flutter/partials/features/auth/forgot_password_screen.hbs
+++ b/templates/flutter/partials/features/auth/forgot_password_screen.hbs
@@ -23,9 +23,6 @@ import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}pr
 @RoutePage()
 {{/if}}
 {{#if flags.isGetX}}
-{{#if (eq flags.routerPackage "auto_route")}}
-@RoutePage()
-{{/if}}
 class ForgotPasswordScreen extends GetView<AuthController> {
   const ForgotPasswordScreen({super.key});
 

--- a/templates/flutter/partials/features/auth/login_screen.hbs
+++ b/templates/flutter/partials/features/auth/login_screen.hbs
@@ -23,9 +23,6 @@ import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}pr
 @RoutePage()
 {{/if}}
 {{#if flags.isGetX}}
-{{#if (eq flags.routerPackage "auto_route")}}
-@RoutePage()
-{{/if}}
 class LoginScreen extends GetView<AuthController> {
   const LoginScreen({super.key});
 

--- a/templates/flutter/partials/features/auth/login_screen.hbs
+++ b/templates/flutter/partials/features/auth/login_screen.hbs
@@ -8,7 +8,7 @@ import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}pr
 {{else if flags.isProvider}}
 import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}presentation/providers/{{else if (eq architecture "mvc")}}controllers/auth/{{else if (eq architecture "mvvm")}}ui/auth/providers/{{else}}features/auth/presentation/providers/{{/if}}auth_provider.dart';
 {{else if flags.isGetX}}
-import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}presentation/controllers/auth/{{else if (eq architecture "mvc")}}controllers/auth/{{else if (eq architecture "mvvm")}}ui/auth/controllers/{{else}}features/auth/presentation/controllers/{{/if}}auth_controller.dart';
+import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}presentation/controllers/auth/{{else if (eq architecture "mvc")}}controllers/auth/{{else if (eq architecture "mvvm")}}ui/auth/controllers/{{else}}features/auth/presentation/providers/{{/if}}auth_controller.dart';
 {{else if flags.isMobX}}
 {{#if flags.usesFlutterHooks}}
 import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}presentation/providers/{{else if (eq architecture "mvc")}}controllers/auth/{{else if (eq architecture "mvvm")}}ui/auth/stores/{{else}}features/auth/presentation/providers/{{/if}}auth_store.dart';
@@ -22,6 +22,45 @@ import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}pr
 {{#if (eq flags.routerPackage "auto_route")}}
 @RoutePage()
 {{/if}}
+{{#if flags.isGetX}}
+{{#if (eq flags.routerPackage "auto_route")}}
+@RoutePage()
+{{/if}}
+class LoginScreen extends GetView<AuthController> {
+  const LoginScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = context.theme.colorScheme;
+    final tt = context.theme.textTheme;
+
+    Future<void> handleLogin() async {
+      if (!(controller.loginFormKey.currentState?.validate() ?? false)) return;
+
+      controller.login(
+        context: context, 
+        email: controller.emailController.text, 
+        password: controller.passwordController.text,
+      );
+    }
+
+    return Obx(() {
+      final isLoading = controller.isLoading.value;
+      return _LoginView(
+        formKey: controller.loginFormKey,
+        emailController: controller.emailController,
+        passwordController: controller.passwordController,
+        obscurePassword: controller.obscurePassword.value,
+        isLoading: isLoading,
+        onToggleObscure: () => controller.obscurePassword.toggle(),
+        onLogin: handleLogin,
+        cs: cs,
+        tt: tt,
+      );
+    });
+  }
+}
+{{else}}
 {{#if flags.usesFlutterHooks}}
 class LoginScreen extends {{#if flags.isRiverpod}}HookConsumerWidget{{else}}HookWidget{{/if}} {
   const LoginScreen({super.key});
@@ -300,6 +339,7 @@ class _LoginScreenState extends {{#if flags.isRiverpod}}ConsumerState<LoginScree
   }
 }
 {{/if}}
+{{/if}}
 
 class _LoginView extends StatelessWidget {
   const _LoginView({
@@ -418,7 +458,7 @@ class _LoginView extends StatelessWidget {
                               {{else if (eq flags.routerPackage "auto_route")}}
                               context.pushRoute(const ForgotPasswordRoute());
                               {{else if flags.isGetX}}
-                              Get.toNamed(AppRoutes.forgotPassword);
+                              Get.toNamed<dynamic>(AppRoutes.forgotPassword);
                               {{else}}
                               Navigator.pushNamed(context, AppRoutes.forgotPassword);
                               {{/if}}
@@ -509,7 +549,7 @@ class _LoginView extends StatelessWidget {
                     {{else if (eq flags.routerPackage "auto_route")}}
                     context.pushRoute(const SignupRoute());
                     {{else if flags.isGetX}}
-                    Get.toNamed(AppRoutes.signup);
+                    Get.toNamed<dynamic>(AppRoutes.signup);
                     {{else}}
                     Navigator.pushNamed(context, AppRoutes.signup);
                     {{/if}}

--- a/templates/flutter/partials/features/auth/signup_screen.hbs
+++ b/templates/flutter/partials/features/auth/signup_screen.hbs
@@ -23,9 +23,6 @@ import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}pr
 @RoutePage()
 {{/if}}
 {{#if flags.isGetX}}
-{{#if (eq flags.routerPackage "auto_route")}}
-@RoutePage()
-{{/if}}
 class SignupScreen extends GetView<AuthController> {
   const SignupScreen({super.key});
 

--- a/templates/flutter/partials/features/auth/signup_screen.hbs
+++ b/templates/flutter/partials/features/auth/signup_screen.hbs
@@ -8,7 +8,7 @@ import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}pr
 {{else if flags.isProvider}}
 import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}presentation/providers/{{else if (eq architecture "mvc")}}controllers/auth/{{else if (eq architecture "mvvm")}}ui/auth/providers/{{else}}features/auth/presentation/providers/{{/if}}auth_provider.dart';
 {{else if flags.isGetX}}
-import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}presentation/controllers/auth/{{else if (eq architecture "mvc")}}controllers/auth/{{else if (eq architecture "mvvm")}}ui/auth/controllers/{{else}}features/auth/presentation/controllers/{{/if}}auth_controller.dart';
+import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}presentation/controllers/auth/{{else if (eq architecture "mvc")}}controllers/auth/{{else if (eq architecture "mvvm")}}ui/auth/controllers/{{else}}features/auth/presentation/providers/{{/if}}auth_controller.dart';
 {{else if flags.isMobX}}
 {{#if flags.usesFlutterHooks}}
 import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}presentation/providers/{{else if (eq architecture "mvc")}}controllers/auth/{{else if (eq architecture "mvvm")}}ui/auth/stores/{{else}}features/auth/presentation/providers/{{/if}}auth_store.dart';
@@ -22,6 +22,50 @@ import 'package:{{flags.appSnake}}/src/{{#if (eq architecture "layer-first")}}pr
 {{#if (eq flags.routerPackage "auto_route")}}
 @RoutePage()
 {{/if}}
+{{#if flags.isGetX}}
+{{#if (eq flags.routerPackage "auto_route")}}
+@RoutePage()
+{{/if}}
+class SignupScreen extends GetView<AuthController> {
+  const SignupScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = context.theme.colorScheme;
+    final tt = context.theme.textTheme;
+
+    Future<void> handleSignup() async {
+      if (!(controller.signUpFormKey.currentState?.validate() ?? false)) return;
+
+      controller.signUp(
+        context: context, 
+        name: controller.nameController.text,
+        email: controller.signUpEmailController.text, 
+        password: controller.signUpPasswordController.text,
+      );
+    }
+
+    return Obx(() {
+      final isLoading = controller.isLoading.value;
+      return _SignupView(
+        formKey: controller.signUpFormKey,
+        nameController: controller.nameController,
+        emailController: controller.signUpEmailController,
+        passwordController: controller.signUpPasswordController,
+        confirmPasswordController: controller.signUpConfirmPasswordController,
+        obscurePassword: controller.signUpObscurePassword.value,
+        obscureConfirmPassword: controller.signUpObscureConfirmPassword.value,
+        isLoading: isLoading,
+        onToggleObscure: () => controller.signUpObscurePassword.toggle(),
+        onToggleConfirmObscure: () => controller.signUpObscureConfirmPassword.toggle(),
+        onSignup: handleSignup,
+        cs: cs,
+        tt: tt,
+      );
+    });
+  }
+}
+{{else}}
 {{#if flags.usesFlutterHooks}}
 class SignupScreen extends {{#if flags.isRiverpod}}HookConsumerWidget{{else}}HookWidget{{/if}} {
   const SignupScreen({super.key});
@@ -332,6 +376,7 @@ class _SignupScreenState extends {{#if flags.isRiverpod}}ConsumerState<SignupScr
   }
 }
 {{/if}}
+{{/if}}
 
 class _SignupView extends StatelessWidget {
   const _SignupView({
@@ -479,7 +524,7 @@ class _SignupView extends StatelessWidget {
                     {{else if (eq flags.routerPackage "auto_route")}}
                     context.pushRoute(const LoginRoute());
                     {{else if flags.isGetX}}
-                    Get.toNamed(AppRoutes.login);
+                    Get.toNamed<dynamic>(AppRoutes.login);
                     {{else}}
                     Navigator.pushNamed(context, AppRoutes.login);
                     {{/if}}


### PR DESCRIPTION
**Description:**
This PR introduces stability and architectural fixes to the Flutter generator templates, specifically targeting configurations that utilize **GetX** alongside the **Feature-First** architecture.

**What was changed?**
- **Auth UI:** Refactored the generated Authentication screens to leverage GetX's native `GetView<AuthController>` paradigm instead of storing controllers locally inside standard StatelessWidgets.
- **Controller Lifecycle:** Updated the `AuthController` generation logic to properly instantiate and cleanly dispose of `TextEditingController` instances on close.
- **Analyzer Compliance:** Resolved all implicit generic inference warnings (`strict_raw_type`) on `GetPage` arrays and `Get.offAllNamed` navigators.
- **Dependency Deduplication:** Patched `pubspec.yaml.hbs` to prevent duplicate `get: ^4.7.3` entries which were causing `flutter pub get` failures.
- **Import Collisions:** Safely hid `Trans` and `ContextExtensionss` from the global GetX import barrel to prevent conflicts with standard localization and screen utility packages.

**Testing:**
Locally verified by running `bun scripts/template-dev.ts` with Git and Node.js.
The generated project passes `flutter pub get` and `dart analyze` with 0 issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved GetX integration across Flutter templates with explicit generics for routing and typed navigation.
  * Simplified and consolidated import/export bundles and adjusted auth controller import paths.
  * Reworked auth screens to use GetX views that drive UI from controller-managed form fields and state.

* **Bug Fixes**
  * Added proper disposal/cleanup for authentication controllers and adjusted navigation transitions.
* **Chores**
  * Made the Get dependency conditional in the generated pubspec.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arjun544/flutter_init/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->